### PR TITLE
change 'generic' to 'tabular' (there is no "generic" FITS spectrum)

### DIFF
--- a/specutils/io/default_loaders/tabular_fits_reader.py
+++ b/specutils/io/default_loaders/tabular_fits_reader.py
@@ -14,7 +14,7 @@ from specutils.spectra import Spectrum1D
 def identify_tabular_fits(origin, *args, **kwargs):
     return (isinstance(args[0], six.string_types) and
             os.path.splitext(args[0].lower())[1] == '.fits' and
-            isinstance(fits.open(args[0]), fits.BinTableHDU)
+            isinstance(fits.open(args[0])[1], fits.BinTableHDU)
            )
 
 

--- a/specutils/io/default_loaders/tabular_fits_reader.py
+++ b/specutils/io/default_loaders/tabular_fits_reader.py
@@ -27,10 +27,10 @@ def tabular_fits(file_name, **kwargs):
     with fits.open(file_name, **kwargs) as hdulist:
         header = hdulist[0].header
 
-        tab = Table.read(file_name)
+        tab = Table.read(hdulist)
 
         meta = {'header': header}
-        wcs = WCS(hdulist[0].header)
+        wcs = WCS(header)
         uncertainty = StdDevUncertainty(tab["err"])
         data = tab["flux"] * Unit("Jy")
 

--- a/specutils/io/default_loaders/tabular_fits_reader.py
+++ b/specutils/io/default_loaders/tabular_fits_reader.py
@@ -18,7 +18,7 @@ def identify_tabular_fits(origin, *args, **kwargs):
            )
 
 
-@data_loader("tabular-fits-reader", identifier=identify_tabular_fits,
+@data_loader("tabular-fits", identifier=identify_tabular_fits,
              dtype=Spectrum1D)
 def tabular_fits(file_name, **kwargs):
     # name is not used; what was it for?

--- a/specutils/io/default_loaders/tabular_fits_reader.py
+++ b/specutils/io/default_loaders/tabular_fits_reader.py
@@ -11,15 +11,18 @@ from specutils.io.registers import data_loader
 from specutils.spectra import Spectrum1D
 
 
-def identify_generic_fits(origin, *args, **kwargs):
+def identify_tabular_fits(origin, *args, **kwargs):
     return (isinstance(args[0], six.string_types) and
-            os.path.splitext(args[0].lower())[1] == '.fits')
+            os.path.splitext(args[0].lower())[1] == '.fits' and
+            isinstance(fits.open(args[0]), fits.BinTableHDU)
+           )
 
 
-@data_loader("generic-fits-reader", identifier=identify_generic_fits,
+@data_loader("tabular-fits-reader", identifier=identify_tabular_fits,
              dtype=Spectrum1D)
-def generic_fits(file_name, **kwargs):
-    name = os.path.basename(file_name.rstrip(os.sep)).rsplit('.', 1)[0]
+def tabular_fits(file_name, **kwargs):
+    # name is not used; what was it for?
+    # name = os.path.basename(file_name.rstrip(os.sep)).rsplit('.', 1)[0]
 
     with fits.open(file_name, **kwargs) as hdulist:
         header = hdulist[0].header

--- a/specutils/io/default_loaders/tabular_fits_writer.py
+++ b/specutils/io/default_loaders/tabular_fits_writer.py
@@ -2,8 +2,8 @@ from astropy.table import Table
 from specutils.io.registers import custom_writer
 
 
-@custom_writer("generic-fits-writer")
-def generic_fits(spectrum, file_name, **kwargs):
+@custom_writer("tabular-fits-writer")
+def tabular_fits(spectrum, file_name, **kwargs):
     flux = spectrum.flux.value
     disp = spectrum.dispersion.value
     meta = spectrum.meta


### PR DESCRIPTION
We should not assume that the default is a tabular format; better to check that
it is.  I'll implement another one for a WCS-based FITS file next.