### PR TITLE
WIP: Added a prototype mix-in class for spectra [DO NOT MERGE!]

### DIFF
--- a/specutils/io/default_loaders/tabular_fits_reader.py
+++ b/specutils/io/default_loaders/tabular_fits_reader.py
@@ -1,8 +1,6 @@
-from __future__ import absolute_import, division
-import six
-
 import os
 
+import six
 from astropy.io import fits
 from astropy.nddata import StdDevUncertainty
 from astropy.table import Table
@@ -14,10 +12,12 @@ from ...spectra import Spectrum1D
 
 
 def identify_tabular_fits(origin, *args, **kwargs):
+    fh = fits.open(args[0])
     return (isinstance(args[0], six.string_types) and
             os.path.splitext(args[0].lower())[1] == '.fits' and
-            isinstance(fits.open(args[0])[1], fits.BinTableHDU)
-            )
+            len(fh) > 1 and
+            isinstance(fh[1], fits.BinTableHDU)
+           )
 
 
 @data_loader("tabular-fits", identifier=identify_tabular_fits,

--- a/specutils/io/default_loaders/tabular_fits_writer.py
+++ b/specutils/io/default_loaders/tabular_fits_writer.py
@@ -4,7 +4,7 @@ from astropy.table import Table
 from ..registers import custom_writer
 
 
-@custom_writer("tabular-fits-writer")
+@custom_writer("tabular-fits")
 def tabular_fits(spectrum, file_name, **kwargs):
     flux = spectrum.flux.value
     disp = spectrum.dispersion.value

--- a/specutils/io/default_loaders/wcs_fits_reader.py
+++ b/specutils/io/default_loaders/wcs_fits_reader.py
@@ -6,7 +6,7 @@ from astropy.io import fits
 from astropy.wcs import WCS
 
 from ..registers import data_loader
-from ...spectra import FITSWCSSpectrum1D,Spectrum1D
+from ...spectra import Spectrum1D
 
 
 def identify_wcs1d_fits(origin, *args, **kwargs):
@@ -34,4 +34,4 @@ def wcs1d_fits(file_name, **kwargs):
 
         meta = {'header': header}
 
-    return FITSWCSSpectrum1D(flux=data, wcs=wcs, meta=meta)
+    return Spectrum1D(flux=data, wcs=wcs, meta=meta)

--- a/specutils/io/default_loaders/wcs_fits_reader.py
+++ b/specutils/io/default_loaders/wcs_fits_reader.py
@@ -5,8 +5,8 @@ from astropy import units as u
 from astropy.io import fits
 from astropy.wcs import WCS
 
-from specutils.io.registers import data_loader
-from specutils.spectra import FITSWCSSpectrum1D
+from ..registers import data_loader
+from ...spectra import FITSWCSSpectrum1D,Spectrum1D
 
 
 def identify_wcs1d_fits(origin, *args, **kwargs):
@@ -17,8 +17,8 @@ def identify_wcs1d_fits(origin, *args, **kwargs):
            )
 
 
-@data_loader("wcs1d-fits-reader", identifier=identify_wcs1d_fits,
-             dtype=FITSWCSSpectrum1D)
+@data_loader("wcs1d-fits", identifier=identify_wcs1d_fits,
+             dtype=Spectrum1D)
 def wcs1d_fits(file_name, **kwargs):
     # name is not used; what was it for?
     # name = os.path.basename(file_name.rstrip(os.sep)).rsplit('.', 1)[0]

--- a/specutils/io/default_loaders/wcs_fits_reader.py
+++ b/specutils/io/default_loaders/wcs_fits_reader.py
@@ -6,7 +6,7 @@ from astropy.io import fits
 from astropy.wcs import WCS
 
 from specutils.io.registers import data_loader
-from specutils.spectra import Spectrum1D
+from specutils.spectra import FITSWCSSpectrum1D
 
 
 def identify_wcs1d_fits(origin, *args, **kwargs):
@@ -18,7 +18,7 @@ def identify_wcs1d_fits(origin, *args, **kwargs):
 
 
 @data_loader("wcs1d-fits-reader", identifier=identify_wcs1d_fits,
-             dtype=Spectrum1D)
+             dtype=FITSWCSSpectrum1D)
 def wcs1d_fits(file_name, **kwargs):
     # name is not used; what was it for?
     # name = os.path.basename(file_name.rstrip(os.sep)).rsplit('.', 1)[0]
@@ -34,5 +34,4 @@ def wcs1d_fits(file_name, **kwargs):
 
         meta = {'header': header}
 
-    return Spectrum1D(flux=data, wcs=wcs, meta=meta)
-
+    return FITSWCSSpectrum1D(flux=data, wcs=wcs, meta=meta)

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -13,7 +13,7 @@ from .spectrum_mixin import OneDSpectrumMixin
 __all__ = ['Spectrum1D']
 
 
-class Spectrum1D(OneDSpectrumMixin,NDDataRef):
+class Spectrum1D(OneDSpectrumMixin, NDDataRef):
     """
     Spectrum container for 1D spectral data.
     """

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -10,7 +10,7 @@ from astropy import units as u
 
 from .spectrum_mixin import OneDSpectrumMixin, FITSWCSMixin
 
-__all__ = ['Spectrum1D']
+__all__ = ['Spectrum1D', 'FITSWCSSpectrum1D']
 
 
 class Spectrum1D(OneDSpectrumMixin,NDDataRef):
@@ -53,9 +53,9 @@ class Spectrum1D(OneDSpectrumMixin,NDDataRef):
                 spectral_axis = spectral_axis * spectral_axis_unit
 
                 if wcs.wcs.restfrq != 0:
-                    self.rest_value = wcs.wcs.restfrq * u.Hz
-                if wcs.wcs.restwav != 0:
-                    self.rest_value = wcs.wcs.restwav * u.AA
+                    self._rest_value = wcs.wcs.restfrq * u.Hz
+                elif wcs.wcs.restwav != 0:
+                    self._rest_value = wcs.wcs.restwav * u.AA
 
         self._spectral_axis = spectral_axis
 

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -57,8 +57,6 @@ class Spectrum1D(OneDSpectrumMixin,NDDataRef):
                 elif wcs.wcs.restwav != 0:
                     self._rest_value = wcs.wcs.restwav * u.AA
 
-        self._spectral_axis = spectral_axis
-
         super(Spectrum1D, self).__init__(data=flux.value, unit=flux.unit,
                                          wcs=wcs, *args, **kwargs)
 

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -7,13 +7,13 @@ from astropy.nddata import NDDataRef
 from astropy.wcs import WCS, WCSSUB_SPECTRAL
 from astropy.units import Unit, Quantity
 from astropy import units as u
-import astropy.units.equivalencies as eq
 
+from .spectrum_mixin import OneDSpectrumMixin, FITSWCSMixin
 
 __all__ = ['Spectrum1D']
 
 
-class Spectrum1D(NDDataRef):
+class Spectrum1D(OneDSpectrumMixin,NDDataRef):
     """
     Spectrum container for 1D spectral data.
     """
@@ -62,119 +62,19 @@ class Spectrum1D(NDDataRef):
         super(Spectrum1D, self).__init__(data=flux.value, unit=flux.unit,
                                          wcs=wcs, *args, **kwargs)
 
-    @property
-    def spectral_axis(self):
-        """
-        The spectral axis data.
 
-        Returns
-        -------
-        ~`astropy.units.Quantity`
-            Spectral axis data as a quantity.
-        """
-        return self._spectral_axis
-
-    @property
-    def flux(self):
-        """
-        Converts the stored data and unit information into a quantity.
-
-        Returns
-        -------
-        ~`astropy.units.Quantity`
-            Spectral data as a quantity.
-        """
-        return self.data * Unit(self.unit)
-
-    def to_flux(self, unit):
-        """
-        Converts the flux data to the specified unit.
-
-        Parameters
-        ----------
-        unit : str or ~`astropy.units.Unit`
-            The unit to conver the flux array to.
-
-        Returns
-        -------
-        ~`astropy.units.Quantity`
-            The converted flux array.
-        """
-        new_data = self.flux.to(
-            unit, equivalencies=eq.spectral_density(self.spectral_axis))
-
-        self._data = new_data.value
-        self._unit = new_data.unit
-
-        return self.flux
 
     @property
     def frequency(self):
-        return self._spectral_axis.to(u.GHz, u.spectral())
+        return self.spectral_axis.to(u.GHz, u.spectral())
 
     @property
     def wavelength(self):
-        return self._spectral_axis.to(u.AA, u.spectral())
+        return self.spectral_axis.to(u.AA, u.spectral())
 
     @property
     def energy(self):
-        return self._spectral_axis.to(u.ev, u.spectral())
+        return self.spectral_axis.to(u.ev, u.spectral())
 
-    @property
-    def velocity_convention(self):
-        return self._velocity_convention
-
-    @velocity_convention.setter
-    def velocity_convention(self, value):
-        if value not in ('relativistic', 'optical', 'radio'):
-            raise ValueError("The allowed velocity conveintions are 'optical' "
-                             "(linear with respect to wavelength), 'radio' "
-                             "(linear with respect to frequency), and 'relativistic'.")
-        self._velocity_convention = value
-
-    @property
-    def rest_value(self):
-        return self._rest_value
-
-    @rest_value.setter
-    def rest_value(self, value):
-        if not hasattr(value, 'unit') or not value.unit.is_equivalent(u.Hz, u.spectral()):
-            raise ValueError("Rest value must be energy/wavelength/frequency equivalent.")
-        self._rest_value = value
-
-    @property
-    def velocity(self):
-        """
-        Converts the spectral axis array to the given velocity space unit given
-        the rest value.
-
-        These aren't input parameters but required Spectrum attributes
-
-        Parameters
-        ----------
-        unit : str or ~`astropy.units.Unit`
-            The unit to convert the dispersion array to.
-        rest : ~`astropy.units.Quantity`
-            Any quantity supported by the standard spectral equivalencies
-            (wavelength, energy, frequency, wave number).
-        type : {"doppler_relativistic", "doppler_optical", "doppler_radio"}
-            The type of doppler spectral equivalency.
-
-        Returns
-        -------
-        ~`astropy.units.Quantity`
-            The converted dispersion array in the new dispersion space.
-        """
-        if not hasattr(self, '_rest_value'):
-            raise ValueError("Cannot get velocity representation of spectral "
-                             "axis without specifying a reference value.")
-        if not hasattr(self, '_velocity_convention'):
-            raise ValueError("Cannot get velocity representation of spectral "
-                             "axis without specifying a velocity convention.")
-
-
-        equiv = getattr(eq, self.velocity_convention)('doppler_{0}'.format(self.rest_value))
-
-        new_data = self.spectral_axis.to(u.km/u.s, equivalencies=equiv)
-
-        return new_data
+class FITSWCSSpectrum1D(FITSWCSMixin, Spectrum1D):
+    pass

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -8,9 +8,9 @@ from astropy.wcs import WCS, WCSSUB_SPECTRAL
 from astropy.units import Unit, Quantity
 from astropy import units as u
 
-from .spectrum_mixin import OneDSpectrumMixin, FITSWCSMixin
+from .spectrum_mixin import OneDSpectrumMixin
 
-__all__ = ['Spectrum1D', 'FITSWCSSpectrum1D']
+__all__ = ['Spectrum1D']
 
 
 class Spectrum1D(OneDSpectrumMixin,NDDataRef):
@@ -24,7 +24,7 @@ class Spectrum1D(OneDSpectrumMixin,NDDataRef):
             flux = Quantity(flux, unit=unit or "Jy")
 
         if spectral_axis is not None and not isinstance(spectral_axis, Quantity):
-            spectral_axis = Quantity(spectral_axis, unit=spectral_axis_unit or "Angstrom")
+            spectral_axis = Quantity(spectral_axis, unit=spectral_axis_unit or u.AA)
 
         # If spectral_axis had not been defined, attempt to use the wcs
         # information, if it exists
@@ -73,6 +73,3 @@ class Spectrum1D(OneDSpectrumMixin,NDDataRef):
     @property
     def energy(self):
         return self.spectral_axis.to(u.ev, u.spectral())
-
-class FITSWCSSpectrum1D(FITSWCSMixin, Spectrum1D):
-    pass

--- a/specutils/spectra/spectrum_mixin.py
+++ b/specutils/spectra/spectrum_mixin.py
@@ -1,0 +1,135 @@
+import logging
+
+import numpy as np
+from astropy.wcs import WCSSUB_SPECTRAL
+from astropy.units import Unit
+from astropy.nddata import NDData
+
+# Use this once in specutils
+# from ..utils.wcs_utils import determine_ctype_from_vconv, convert_spectral_axis
+
+from spectral_cube.spectral_axis import determine_ctype_from_vconv, convert_spectral_axis
+
+__all__ = ['Spectrum1D']
+
+
+class SpectrumMixin(object):
+
+    @property
+    def _spectral_axis_numpy_index(self):
+        return self.data.ndim - 1 - self.wcs.wcs.spec
+
+    @property
+    def _spectral_axis_len(self):
+        """
+        How many elements are in the spectral dimension?
+        """
+        return self.data.shape[self._spectral_axis_numpy_index]
+
+    @property
+    def _data_with_spectral_axis_last(self):
+        """
+        Returns a view of the data with the spectral axis last
+        """
+        if self._spectral_axis_numpy_index == self.data.ndim - 1:
+            return self.data
+        else:
+            return self.data.swapaxes(self._spectral_axis_numpy_index, self.data.ndim - 1)
+
+    @property
+    def _data_with_spectral_axis_first(self):
+        """
+        Returns a view of the data with the spectral axis first
+        """
+        if self._spectral_axis_numpy_index == 0:
+            return self.data
+        else:
+            return self.data.swapaxes(self._spectral_axis_numpy_index, 0)
+
+    @property
+    def spectral_wcs(self):
+        return self.wcs.sub([WCSSUB_SPECTRAL])
+
+    @property
+    def spectral_axis(self):
+        """
+        Returns a Quantity array with the values of the spectral axis.
+        """
+
+        spectral_wcs = self.spectral_wcs
+
+        # Lim: What if I have wavelength arrays and I don't want WCS conversion?
+        # Tom: this is beyond the scope of the prototype work, your question is more
+        #      how to make a WCS object that contains a wavelngth array. The mixin
+        #      is for NDData which assumes a WCS has been created (not necessarily
+        #      a *FITS* WCS, just some transformation object).
+
+        if spectral_wcs.naxis == 0:
+            raise TypeError('WCS has no spectral axis')
+
+        spectral_axis = spectral_wcs.all_pix2world(np.arange(self._spectral_axis_len), 0)[0]
+
+        # Try to get the dispersion unit information
+        try:
+            spectral_unit = self.wcs.wcs.cunit[self.wcs.wcs.spec]
+        except AttributeError:
+            logging.warning("No spectral_axis unit information in WCS.")
+            spectral_unit = Unit("")
+
+        spectral_axis = spectral_axis * spectral_unit
+
+        return spectral_axis
+
+    def with_spectral_units(self, unit, velocity_convention=None,
+                            rest_value=None):
+        """
+        Example method that returns a new cube with updated spectral axis units
+        """
+
+        # TODO: avoid the two function calls, make a wrapper?
+
+        out_ctype = determine_ctype_from_vconv(self.wcs.wcs.ctype[self.wcs.wcs.spec],
+                                               unit, velocity_convention=velocity_convention)
+
+        new_wcs = convert_spectral_axis(self._wcs, unit, out_ctype,
+                                        rest_value=rest_value)
+
+        return self.__class__(self, wcs=new_wcs)
+
+    # Example methods follow to demonstrate how methods can be written to be
+    # agnostic of the non-spectral dimensions.
+
+    def substract_background(self, background):
+        """
+        Proof of concept, this subtracts a background spectrum-wise
+        """
+
+        data = self._data_with_spectral_axis_last
+
+        if callable(background):
+            # create substractable array
+            pass
+        elif (isinstance(background, np.ndarray) and
+              background.shape == data[-1].shape):
+            substractable_continuum = background
+        else:
+            raise ValueError("background needs to be callable or have the same shape as the spectum")
+
+       data[-1] -= substractable_continuum
+
+    def normalize(self):
+        """
+        Proof of concept, this normalizes each spectral dimension based
+        on a trapezoidal integration.
+        """
+
+        # this gets a view - if we want normalize to return a new NDData object
+        # then we should make _data_with_spectral_axis_first return a copy.
+        data = self._data_with_spectral_axis_first
+
+        dx = np.diff(self.spectral_axis)
+        dy = 0.5 * (data[:-1] + data[1:])
+
+        norm = np.sum(dx * dy.transpose(), axis=-1).transpose()
+
+        data /= norm

--- a/specutils/spectra/spectrum_mixin.py
+++ b/specutils/spectra/spectrum_mixin.py
@@ -1,6 +1,7 @@
 import logging
 
 import numpy as np
+import astropy.wcs
 from astropy.wcs import WCSSUB_SPECTRAL
 from astropy.units import Unit
 from astropy.nddata import NDData
@@ -196,7 +197,6 @@ class OneDSpectrumMixin(object):
 
         return new_data
 
-class FITSWCSMixin(object):
 
     def with_spectral_unit(self, unit, velocity_convention=None,
                            rest_value=None):
@@ -256,6 +256,12 @@ class FITSWCSMixin(object):
                      even if your cube has air wavelength units
 
         """
+
+        if not isinstance(self.wcs, astropy.wcs.WCS):
+            raise NotImplementedError("Spectral unit conversion for "
+                                      "non-FITS WCSes have not yet "
+                                      "been implemented.")
+
         # Allow string specification of units, for example
         if not isinstance(unit, u.Unit):
             unit = u.Unit(unit)

--- a/specutils/spectra/spectrum_mixin.py
+++ b/specutils/spectra/spectrum_mixin.py
@@ -6,6 +6,7 @@ from astropy.units import Unit
 from astropy.nddata import NDData
 from astropy import units as u
 import astropy.units.equivalencies as eq
+from astropy.utils.decorators import lazyproperty
 
 # Use this once in specutils
 from ..utils.wcs_utils import determine_ctype_from_vconv, convert_spectral_axis
@@ -60,7 +61,7 @@ class OneDSpectrumMixin(object):
             m1 = self.wcs.forward_transform | models.Mapping((2,))
             return m1 # this isn't really right, we need a wrapper still
 
-    @property
+    @lazyproperty
     def spectral_axis(self):
         """
         Returns a Quantity array with the values of the spectral axis.
@@ -68,9 +69,6 @@ class OneDSpectrumMixin(object):
         *PROBLEM*: THIS IS EXPENSIVE! How do we make this not evaluate each
         time?  Cache?
         """
-
-        if hasattr(self, '_spectral_axis'):
-            return self._spectral_axis
 
         spectral_wcs = self.spectral_wcs
 
@@ -99,9 +97,6 @@ class OneDSpectrumMixin(object):
             spectral_unit = Unit("")
 
         spectral_axis = spectral_axis * spectral_unit
-
-        # cache the result
-        self._spectral_axis = spectral_axis
 
         return spectral_axis
 

--- a/specutils/spectra/wcs_wrappers.py
+++ b/specutils/spectra/wcs_wrappers.py
@@ -1,0 +1,17 @@
+import numpy as np
+from astropy.modeling import models
+from astropy import units as u
+from astropy import coordinates as coords
+from gwcs import wcs, utils
+from gwcs import coordinate_frames as cf
+from astropy.modeling.tabular import Tabular1D
+
+def tabular_wcs(xarray):
+
+    coordinateframe = cf.CoordinateFrame(naxes=1, axes_type=('SPECTRAL',), axes_order=(0,))
+    specframe = cf.SpectralFrame(unit=xarray.unit, axes_order=(0,))
+    transform = Tabular1D(np.arange(len(xarray)), xarray.value)
+
+    tabular_gwcs = wcs.WCS([(coordinateframe, transform), (specframe, None)])
+
+    return tabular_gwcs


### PR DESCRIPTION
This is a prototype implementation of a mix-in class for spectra. This includes a couple of example methods which may or may not be in the list of things we want in a core API, but we are just including them as examples of how to implement these kinds of things. Also we don't deal with flux units etc at the moment. This is very much just to see how the class structure would work and how to write methods that can be agnostic of the other dimensions.

Things this PR is NOT concerned with:

* Actual naming of methods
* Whether methods really belong in base class
* WCS for things like lookup tables

Example usage:

```python
In [1]: import numpy as np
   ...: from astropy.io import fits
   ...: from astropy.wcs import WCS
   ...: from astropy import units as u
   ...: from astropy.nddata import NDData
   ...: from specutils.spectra.spectrum_mixin import SpectrumMixin

In [2]: hdu = fits.open('l1448_13co_small.fits')[0]
   ...: data = hdu.data
   ...: wcs = WCS(hdu.header)

In [3]: class SpectralCube(NDData, SpectrumMixin):
   ...:     pass

In [4]: nd = SpectralCube(data=data, wcs=wcs)
   ...: 

In [5]: print(nd.spectral_axis)
   ...: 
[ 2528.19489695  2594.61850695  2661.04211695  2727.46572695  2793.88933695
  2860.31294695  2926.73655695  2993.16016695  3059.58377695  3126.00738695
  3192.43099695  3258.85460695  3325.27821695  3391.70182695  3458.12543695
  3524.54904695  3590.97265695  3657.39626695  3723.81987695  3790.24348695
  3856.66709695  3923.09070695  3989.51431695  4055.93792695  4122.36153695
  4188.78514695  4255.20875695  4321.63236695  4388.05597695  4454.47958695
  4520.90319695  4587.32680695  4653.75041695  4720.17402695  4786.59763695
  4853.02124695  4919.44485695  4985.86846695  5052.29207695  5118.71568695
  5185.13929695  5251.56290695  5317.98651695  5384.41012695  5450.83373695
  5517.25734695  5583.68095695  5650.10456695  5716.52817695  5782.95178695
  5849.37539695  5915.79900695  5982.22261695] m / s
```

We can get a new SpectralCube with different spectral units:

```python
In [6]: nd_freq = nd.with_spectral_units(u.Hz, rest_value=200 * u.GHz)
   ...: 
INFO: overwriting NDData's current wcs with specified wcs. [astropy.nddata.nddata]
INFO:astropy:overwriting NDData's current wcs with specified wcs.

In [7]: print(nd_freq.spectral_axis)
   ...: 
[  1.99998313e+11   1.99998269e+11   1.99998225e+11   1.99998180e+11
   1.99998136e+11   1.99998092e+11   1.99998048e+11   1.99998003e+11
   1.99997959e+11   1.99997915e+11   1.99997870e+11   1.99997826e+11
   1.99997782e+11   1.99997737e+11   1.99997693e+11   1.99997649e+11
   1.99997604e+11   1.99997560e+11   1.99997516e+11   1.99997471e+11
   1.99997427e+11   1.99997383e+11   1.99997339e+11   1.99997294e+11
   1.99997250e+11   1.99997206e+11   1.99997161e+11   1.99997117e+11
   1.99997073e+11   1.99997028e+11   1.99996984e+11   1.99996940e+11
   1.99996895e+11   1.99996851e+11   1.99996807e+11   1.99996762e+11
   1.99996718e+11   1.99996674e+11   1.99996630e+11   1.99996585e+11
   1.99996541e+11   1.99996497e+11   1.99996452e+11   1.99996408e+11
   1.99996364e+11   1.99996319e+11   1.99996275e+11   1.99996231e+11
   1.99996186e+11   1.99996142e+11   1.99996098e+11   1.99996053e+11
   1.99996009e+11] Hz
```

The following normalizes in-place (we probably want to return a copy, but again, prototype...)

```python
In [16]: nd.data.mean()
    ...: 
0.518896

In [17]: nd.normalize()
    ...: 

In [18]: nd.data.mean()
    ...: 
0.000286457
```

Example background subtraction:

```python
In [19]: print(nd.substract_background(np.ones(nd._data_with_spectral_axis_last[-1].shape)))
```

Interpolation (in this case returns an image):

```python
In [20]: nd.spectral_interpolation(5 * u.km/u.s)
Out [20]: [[ 0.98596281  0.85895475  1.15403355 ...,  0.33115755  0.56095078
   0.32875844]
 [ 0.82210455  0.90938824  0.98433012 ...,  0.3770409   0.30789063
   0.36561956]
 [ 0.71441961  1.01067758  0.90591533 ...,  0.5859509   0.08102035
   0.21377534]
 ..., 
 [ 0.56883245  0.73192955  0.68707602 ...,  0.31134169  0.24132472
   0.33705913]
 [ 0.73597817  0.57150443  0.46302539 ...,  0.48713222  0.23206653
   0.53416268]
 [ 0.71822787  0.62636963  0.75206286 ...,  0.34204201  0.33822349
   0.28919433]]
```

Work done collaboratively with @bsipocz 