### PR TITLE
Add stub for new spectral_resolution() method with fleshed out docstring

### DIFF
--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -197,8 +197,8 @@ class Spectrum1D(NDDataRef):
 
         >>> R = spectrum1d.spectral_resolution(
         ... np.linspace(4000, 8000, 40001)[:, np.newaxis] * u.Angstrom,
-        ... np.arange(-10, +10, 201) * u.Angstrom)
-        >>> assert R.shape == (40000, 21)
+        ... np.linspace(-10, +10, 201) * u.Angstrom)
+        >>> assert R.shape == (40000, 200)
         >>> assert np.allclose(R.sum(axis=1), 1.)
 
         Parameters

--- a/specutils/spectra/spectrum1d.py
+++ b/specutils/spectra/spectrum1d.py
@@ -179,3 +179,46 @@ class Spectrum1D(NDDataRef):
         new_data = self.spectral_axis.to(u.km/u.s, equivalencies=equiv)
 
         return new_data
+
+
+    def spectral_resolution(true_dispersion, delta_dispersion, axis=-1):
+        """Evaluate the probability distribution of the spectral resolution.
+
+        For example, to tabulate a binned resolution function at 6000A
+        covering +/-10A in 0.2A steps:
+
+        >>> R = spectrum1d.spectral_resolution(
+        ... 6000 * u.Angstrom, np.linspace(-10, 10, 51) * u.Angstrom)
+        >>> assert R.shape == (50,)
+        >>> assert np.allclose(R.sum(), 1.)
+
+        To build a sparse resolution matrix for true wavelengths 4000-8000A
+        in 0.1A steps:
+
+        >>> R = spectrum1d.spectral_resolution(
+        ... np.linspace(4000, 8000, 40001)[:, np.newaxis] * u.Angstrom,
+        ... np.arange(-10, +10, 201) * u.Angstrom)
+        >>> assert R.shape == (40000, 21)
+        >>> assert np.allclose(R.sum(axis=1), 1.)
+
+        Parameters
+        ----------
+        true_dispersion : ~`astropy.units.Quantity`
+            True value(s) of dispersion for which the resolution should be
+            evaluated.
+        delta_dispersion : ~`astropy.units.Quantity`
+            Array of (observed - true) dispersion bin edges to integrate the
+            resolution probability density over.
+        axis : int
+            Which axis of ``delta_dispersion`` contains the strictly increasing
+            dispersion values to interpret as bin edges.  The dimension of
+            ``delta_dispersion`` along this axis must be at least two.
+
+        Returns
+        -------
+        numpy array
+            Array of dimensionless probabilities calculated as the integral of
+            P(observed | true) over each bin in (observed - true). The output
+            shape is the result of broadcasting the input shapes.
+        """
+        pass


### PR DESCRIPTION
See the discussion in the #spectral-resolution slack channel for background.

The goal here is to provide a uniform way to query the spectral resolution in a way that is sufficiently general to encompass any reasonable internal representation (tabulated, parameterized, sigmas, etc), but still practical for efficient computations (weighted coadds, resampling, etc).