### PR TITLE
Extend data loaders wcs1d fits loader

### DIFF
--- a/specutils/io/default_loaders/wcs_fits.py
+++ b/specutils/io/default_loaders/wcs_fits.py
@@ -60,7 +60,7 @@ def wcs1d_fits_loader(file_name, spectral_axis_unit=None, flux_unit=None,
         header = hdulist[hdu_idx].header
         wcs = WCS(header)
 
-        if w.naxis != 1:
+        if wcs.naxis != 1:
             raise ValueError('FITS fle input to wcs1d_fits_loader is not 1D')
 
         if 'BUNIT' in header:

--- a/specutils/io/default_loaders/wcs_fits.py
+++ b/specutils/io/default_loaders/wcs_fits.py
@@ -29,9 +29,10 @@ def identify_wcs1d_fits(origin, *args, **kwargs):
              dtype=Spectrum1D, extensions=['fits'])
 def wcs1d_fits_loader(file_name, spectral_axis_unit=None, **kwargs):
     """
-    Loader for spectra in FITS-files with defined WCS. Attempted to parse
-    specific keywords to determine unit information. Optional spectral axis
-    unit definition can be provided.
+    Loader for single spectrum-per-HDU spectra in FITS files, with the spectral
+    axis stored in the header as FITS-WCS.  The flux unit of the spectrum is
+    determined by the 'BUNIT' keyword of the HDU (if present), while the
+    spectral axis unit is set by the WCS's 'CUNIT'.
 
     Parameters
     ----------

--- a/specutils/io/default_loaders/wcs_fits.py
+++ b/specutils/io/default_loaders/wcs_fits.py
@@ -27,7 +27,7 @@ def identify_wcs1d_fits(origin, *args, **kwargs):
 
 @data_loader("wcs1d-fits", identifier=identify_wcs1d_fits,
              dtype=Spectrum1D, extensions=['fits'])
-def wcs1d_fits_loader(file_name, spectral_axis_unit=None, **kwargs):
+def wcs1d_fits_loader(file_name, spectral_axis_unit=None, hdu_idx=0, **kwargs):
     """
     Loader for single spectrum-per-HDU spectra in FITS files, with the spectral
     axis stored in the header as FITS-WCS.  The flux unit of the spectrum is
@@ -40,6 +40,8 @@ def wcs1d_fits_loader(file_name, spectral_axis_unit=None, **kwargs):
         The path to the FITS file.
     spectral_axis_unit: str or unit, optional
         Optional string or unit object to specify units of spectral axis.
+    hdu_idx : int
+        The index of the HDU to load into this spectrum.
 
     Notes
     -----
@@ -48,13 +50,13 @@ def wcs1d_fits_loader(file_name, spectral_axis_unit=None, **kwargs):
     logging.info("Spectrum file looks like wcs1d-fits")
 
     with fits.open(file_name, **kwargs) as hdulist:
-        header = hdulist[0].header
+        header = hdulist[hdu_idx].header
         wcs = WCS(header)
 
         if 'BUNIT' in header:
             data = u.Quantity(hdulist[0].data, unit=header['BUNIT'])
         else:
-            data = hdulist[0].data
+            data = hdulist[hdu_idx].data
 
         if spectral_axis_unit is not None:
             wcs.wcs.cunit[0] = spectral_axis_unit


### PR DESCRIPTION
See https://github.com/astropy/specutils/pull/376/files#r234499795 for some more context

Note that while updating the docstring I realized the loader itself had some significant corner cases to worry about.  I think this PR makes it reasonably safe within the bounds of what the docstring claims it does.